### PR TITLE
Update index.ts

### DIFF
--- a/packages/hub-nodejs/examples/chron-feed/index.ts
+++ b/packages/hub-nodejs/examples/chron-feed/index.ts
@@ -2,6 +2,7 @@ import {
   CastAddMessage,
   fromFarcasterTime,
   getSSLHubRpcClient,
+  getInsecureHubRpcClient,
   HubAsyncResult,
   HubRpcClient,
   isCastAddMessage,


### PR DESCRIPTION
Imports getInsecureHubRpcClient by default. (Needed when connecting to a node without SSL, like a local hub.)